### PR TITLE
Add GIF_CTRL register

### DIFF
--- a/include/ps2s/gs.h
+++ b/include/ps2s/gs.h
@@ -171,6 +171,7 @@ void ReorderClut(tU32* oldClut, tU32* newClut);
 
 namespace GIF {
 namespace Registers {
+    static volatile tU32* const ctrl = (volatile tU32*)0x10003000;
     static volatile tU128* const fifo = (volatile tU128*)0x10006000;
 }
 }


### PR DESCRIPTION
Going to be used by `ps2gl` to clear any leftover state the GIF is in.